### PR TITLE
Delete identity provider objects

### DIFF
--- a/kcloader/resource/__init__.py
+++ b/kcloader/resource/__init__.py
@@ -7,6 +7,7 @@ from .custom_authentication_resource import SingleCustomAuthenticationResource
 from .role_resource import RoleResource
 from .client_scope_resource import ClientScopeResource
 from .identity_provider_resource import IdentityProviderResource, IdentityProviderMapperResource
+from .identity_provider_resource import IdentityProviderManager
 from .user_federation_resource import UserFederationResource
 from .realm_resource import RealmResource
 

--- a/kcloader/resource/identity_provider_resource.py
+++ b/kcloader/resource/identity_provider_resource.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from copy import copy
+from glob import glob
 
 import kcapi
 
@@ -14,15 +15,18 @@ logger = logging.getLogger(__name__)
 
 
 class IdentityProviderResource(SingleResource):
+    _resource_name = 'identity-provider/instances'
+    _resource_id = 'alias'
     def __init__(self, resource):
         super().__init__({
-            'name': 'identity-provider/instances',
-            'id': 'alias',
+            'name': self._resource_name,
+            'id': self._resource_id,
             **resource,
         })
         self.datadir = resource['datadir']
 
     def publish_self(self):
+        # self._ids_to_delete()
         return super().publish()
 
     def publish_mappers(self):
@@ -35,7 +39,56 @@ class IdentityProviderResource(SingleResource):
     def publish(self):
         status = self.publish_self()
         status = status and self.publish_mappers()
+        # self._ids_to_delete()
         return status
+
+
+class IdentityProviderManager:
+    _resource_name = IdentityProviderResource._resource_name
+    _resource_id = IdentityProviderResource._resource_id
+
+    def __init__(self, keycloak_api: kcapi.sso.Keycloak, realm: str, datadir: str):
+        self.keycloak_api = keycloak_api
+        self.realm = realm
+        self.datadir = datadir
+        self.resource_api = self.keycloak_api.build(self._resource_name, self.realm)
+
+        idp_filepaths = glob(os.path.join(datadir, f"{realm}/identity-provider/*.json"))
+        self.resources = [
+            IdentityProviderResource({
+                'path': idp_filepath,
+                'keycloak_api': keycloak_api,
+                'realm': realm,
+                'datadir': datadir,
+            })
+            for idp_filepath in idp_filepaths
+        ]
+
+    def publish(self):
+        create_ids, delete_ids = self._difference_ids()
+        status = True
+        for resource in self.resources:
+            status = status and resource.publish()
+        for obj_id in delete_ids:
+            self.resource_api.remove(obj_id)
+            status = True
+        return status
+
+    def _difference_ids(self):
+        """
+        If IdP is present on server but missing in datadir, then it needs to ber removed.
+        This function will return list of ids (aliases) that needs to be removed.
+        """
+        idp_filepaths = glob(os.path.join(self.datadir, f"{self.realm}/identity-provider/*.json"))
+        file_docs = [read_from_json(idp_filepath) for idp_filepath in idp_filepaths]
+        file_ids = [doc[self._resource_id] for doc in file_docs]
+        server_objs = self.resource_api.all()
+        server_ids = [obj[self._resource_id] for obj in server_objs]
+        # remove objects that are on server, but missing in datadir
+        delete_ids = list(set(server_ids).difference(file_ids))
+        # create objects that are in datdir, but missing on server
+        create_ids = list(set(file_ids).difference(server_ids))
+        return create_ids, delete_ids
 
 
 class IdentityProviderMapperResource(SingleResource):

--- a/test/kcloader/resource/test_identity_provider_resource.py
+++ b/test/kcloader/resource/test_identity_provider_resource.py
@@ -3,61 +3,92 @@ import unittest
 from glob import glob
 from copy import copy
 
-from kcloader.resource import IdentityProviderResource, IdentityProviderMapperResource
+from kcloader.resource import IdentityProviderResource, IdentityProviderMapperResource, IdentityProviderManager
 from kcloader.tools import read_from_json, find_in_list
 from ...helper import TestBed, remove_field_id
 
 
-class TestIdentityProviderResource(unittest.TestCase):
-    def test_publish_self(self):
-        idp_alias = "ci0-idp-saml-0"
-        expected_idp = {
-            'addReadTokenRoleOnCreate': False,
-            'alias': 'ci0-idp-saml-0',
-            'authenticateByDefault': False,
-            'config': {'allowCreate': 'true',
-                       'authnContextClassRefs': '["aa","bb"]',
-                       'authnContextComparisonType': 'exact',
-                       'authnContextDeclRefs': '["cc","dd"]',
-                       'entityId': 'https://172.17.0.2:8443/auth/realms/ci0-realm',
-                       'nameIDPolicyFormat': 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-                       'principalType': 'SUBJECT',
-                       'signatureAlgorithm': 'RSA_SHA256',
-                       'singleLogoutServiceUrl': 'https://172.17.0.6:8443/logout',
-                       'singleSignOnServiceUrl': 'https://172.17.0.6:8443/signon',
-                       'syncMode': 'IMPORT',
-                       'useJwksUrl': 'true',
-                       'wantAssertionsEncrypted': 'true',
-                       'xmlSigKeyInfoKeyNameTransformer': 'KEY_ID'},
-            'displayName': 'ci0-idp-saml-0-displayName',
-            'enabled': True,
-            'firstBrokerLoginFlowAlias': 'first broker login',
-            # 'internalId': '762712d6-6f2c-4d93-adc0-dd3aed625c9c',
-            'linkOnly': False,
-            'providerId': 'saml',
-            'storeToken': False,
-            'trustEmail': False,
-            'updateProfileFirstLoginMode': 'on',
-        }
+# def setUpModule():
+#     pass  # createConnection()
+#
+#
+# def tearDownModule():
+#     pass  # closeConnection()
 
-        testbed = TestBed(realm='ci0-realm')
+
+class TestIdentityProviderBase(unittest.TestCase):
+    # def setUp(self):
+    #     pass
+    #
+    # def tearDown(self):
+    #     pass
+
+    @classmethod
+    def setUpClass(cls):
+        cls.idp_alias = "ci0-idp-saml-0"
+        cls.testbed = TestBed(realm='ci0-realm')
+        testbed = cls.testbed
         idp_filepath = os.path.join(testbed.DATADIR, f"{testbed.REALM}/identity-provider/ci0-idp-saml-0.json")
-        idp_resource = IdentityProviderResource({
+        cls.idp_resource = IdentityProviderResource({
             'path': idp_filepath,
             'keycloak_api': testbed.kc,
             'realm': testbed.REALM,
             'datadir': testbed.DATADIR,
         })
-        idp_api = testbed.kc.build("identity-provider", testbed.REALM)
+        cls.idp_api = testbed.kc.build("identity-provider", testbed.REALM)
 
         # create min realm first, ensure clean start
         testbed.kc.admin().remove(testbed.REALM)
         testbed.kc.admin().create({"realm": testbed.REALM})
 
         # check clean start
-        self.assertFalse(idp_api.findFirstByKV("alias", idp_alias))
-        # END prepare
-        # =============================================================================================
+        assert cls.idp_api.all() == []
+
+    @classmethod
+    def tearDownClass(cls):
+        # Removing realm make sense. But debugging is easier if realm is left.
+        pass
+
+
+class TestIdentityProviderResource(TestIdentityProviderBase):
+    expected_idp = {
+        'addReadTokenRoleOnCreate': False,
+        'alias': 'ci0-idp-saml-0',
+        'authenticateByDefault': False,
+        'config': {'allowCreate': 'true',
+                   'authnContextClassRefs': '["aa","bb"]',
+                   'authnContextComparisonType': 'exact',
+                   'authnContextDeclRefs': '["cc","dd"]',
+                   'entityId': 'https://172.17.0.2:8443/auth/realms/ci0-realm',
+                   'nameIDPolicyFormat': 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+                   'principalType': 'SUBJECT',
+                   'signatureAlgorithm': 'RSA_SHA256',
+                   'singleLogoutServiceUrl': 'https://172.17.0.6:8443/logout',
+                   'singleSignOnServiceUrl': 'https://172.17.0.6:8443/signon',
+                   'syncMode': 'IMPORT',
+                   'useJwksUrl': 'true',
+                   'wantAssertionsEncrypted': 'true',
+                   'xmlSigKeyInfoKeyNameTransformer': 'KEY_ID'},
+        'displayName': 'ci0-idp-saml-0-displayName',
+        'enabled': True,
+        'firstBrokerLoginFlowAlias': 'first broker login',
+        # 'internalId': '762712d6-6f2c-4d93-adc0-dd3aed625c9c',
+        'linkOnly': False,
+        'providerId': 'saml',
+        'storeToken': False,
+        'trustEmail': False,
+        'updateProfileFirstLoginMode': 'on',
+    }
+
+    # 0.7 sec for setUpClass()
+    # def test_noop(self):
+    #     pass
+
+    def test_publish_self(self):
+        idp_resource = self.idp_resource
+        idp_api = self.idp_api
+        idp_alias = self.idp_alias
+        expected_idp = self.expected_idp
 
         # create IdP
         creation_state = idp_resource.publish_self()
@@ -86,7 +117,64 @@ class TestIdentityProviderResource(unittest.TestCase):
         # publish same data again
         creation_state = idp_resource.publish_self()
         self.assertTrue(creation_state)
+        idp_all = idp_api.all()
+        self.assertEqual(len(idp_all), 1)
+        idp_c = idp_all[0]
+        self.assertEqual(idp_c, idp_c | expected_idp)
         self.assertEqual('ci0-idp-saml-0-displayName', idp_api.findFirstByKV("alias", idp_alias)['displayName'])
+
+
+class TestIdentityProviderManager(TestIdentityProviderBase):
+    def test_publish(self):
+        # also test helper methods
+        idp_api = self.idp_api
+        idp_alias = self.idp_alias
+        manager = IdentityProviderManager(self.testbed.kc, self.testbed.REALM, self.testbed.DATADIR)
+
+        create_ids, delete_ids = manager._difference_ids()
+        self.assertEqual([idp_alias], create_ids)
+        self.assertEqual([], delete_ids)
+
+        creation_state = manager.publish()
+        self.assertTrue(creation_state)
+        idp_all = idp_api.all()
+        self.assertEqual([idp_alias], [obj["alias"] for obj in idp_all])
+
+        create_ids, delete_ids = manager._difference_ids()
+        self.assertEqual([], create_ids)
+        self.assertEqual([], delete_ids)
+
+        creation_state = manager.publish()
+        self.assertTrue(creation_state)  # TODO false
+        idp_all = idp_api.all()
+        self.assertEqual([idp_alias], [obj["alias"] for obj in idp_all])
+
+        # ------------------------------------------------------------------------------
+        # create an additional IdP
+        self.idp_api.create({
+            'alias': 'ci0-idp-x-to-be-deleted',
+            'displayName': 'ci0-idp-x-to-be-DELETED',
+            'config': {
+                'singleLogoutServiceUrl': 'https://172.17.0.6:8443/logout-x',
+                'singleSignOnServiceUrl': 'https://172.17.0.6:8443/signon-x',
+            },
+            'enabled': True,
+            'providerId': 'saml',
+        }).isOk()
+        idp_all = self.idp_api.all()
+        self.assertEqual(len(idp_all), 2)
+        idp_aliases = sorted([obj["alias"] for obj in idp_all])
+        self.assertListEqual(sorted(["ci0-idp-x-to-be-deleted", "ci0-idp-saml-0"]), idp_aliases)
+
+        create_ids, delete_ids = manager._difference_ids()
+        self.assertEqual([], create_ids)
+        self.assertEqual(['ci0-idp-x-to-be-deleted'], delete_ids)
+
+        # check extra IdP is deleted
+        creation_state = manager.publish()
+        self.assertTrue(creation_state)
+        idp_all = idp_api.all()
+        self.assertEqual([idp_alias], [obj["alias"] for obj in idp_all])
 
 
 class TestIdentityProviderMapperResource(unittest.TestCase):


### PR DESCRIPTION
Identity provider is deleted if there is no corresponding json file.

A Manager class is added to help with deletion. Something is needed as (IdentityProvider)Resource class is 1:1 related with a single json file, so it can only create/update a single keycloak object.
