### PR TITLE
Import client roles, without composites

### DIFF
--- a/kcloader/resource/client_resource.py
+++ b/kcloader/resource/client_resource.py
@@ -320,10 +320,11 @@ class SingleClientResource(SingleResource):
                 oo["protocolMappers"] = sorted(oo["protocolMappers"], key=lambda pm: pm["name"])
 
         # sort obj2 - it is return by API
-        obj2 = json.loads(json.dumps(obj2, sort_keys=True))
-        # obj1 - we added and remove authenticationFlowBindingOverrides
-        # sort is needed too
-        obj1 = json.loads(json.dumps(obj1, sort_keys=True))
+        # obj2 = json.loads(json.dumps(obj2, sort_keys=True))
+        # obj1 - we added and remove authenticationFlowBindingOverrides, sort is needed too
+        # obj1 = json.loads(json.dumps(obj1, sort_keys=True))
+        obj1 = SortedDict(obj1)
+        obj2 = SortedDict(obj2)
 
         # debug
         # with open("a", "w") as ff:

--- a/kcloader/resource/client_resource.py
+++ b/kcloader/resource/client_resource.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import json
 from glob import glob
 from copy import copy
 from sortedcontainers import SortedDict

--- a/kcloader/resource/client_resource.py
+++ b/kcloader/resource/client_resource.py
@@ -38,11 +38,6 @@ class ClientRoleResource(SingleResource):
                 self.body["composite"] = False
                 self.body.pop("composites")
         creation_state = self.resource.publish_object(self)
-        if creation_state:
-            # This is now handled by kcapi.ClientRoleCRUD.create()
-            # KC 9.0 - if (client) role was just created, attributes were ignored
-            # publish role a second time, to set also attributes
-            creation_state2 = self.resource.publish_object(self)
         return creation_state
 
     def is_equal(self, obj):

--- a/kcloader/resource/resource_publisher.py
+++ b/kcloader/resource/resource_publisher.py
@@ -76,7 +76,6 @@ class ResourcePublisher:
                         # Nothing to change
                         return False
 
-                # TODO BUG here - update URL is https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/d8d61af4-186f-4293-b618-093b45db27c8
                 http_ok = resource_api.update(resource_id, self.body).isOk() # this ?
 
                 return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = [
 requires-python = ">=3.8"
 
 dependencies = [
-    "kcapi>=1.0.36",
+    "kcapi>=1.0.37",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.8"
 
 dependencies = [
     "kcapi>=1.0.37",
+    "sortedcontainers>=2.4.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = [
 requires-python = ">=3.8"
 
 dependencies = [
-    "kcapi>=1.0.35",
+    "kcapi>=1.0.36",
 ]
 
 [project.optional-dependencies]

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -446,6 +446,8 @@ class TestClientRoleResource(TestCaseBase):
         # TODO test with simple ci0-client-0.json and with some composite role
         role_filepath = os.path.join(self.testbed.DATADIR, "ci0-realm/clients/client-0/roles/ci0-client0-role1b.json")
         expected_role = json.load(open(role_filepath))
+        # make sure we do test "attributes". They are just easy to miss.
+        self.assertEqual({'ci0-client0-role1b-key0': ['ci0-client0-role1b-value0']}, expected_role["attributes"])
 
         role_resource = ClientRoleResource({
             'path': role_filepath,
@@ -484,6 +486,8 @@ class TestClientRoleResource(TestCaseBase):
             sorted([role["name"] for role in roles_b])
         )
         role_b = find_in_list(roles_b, name='ci0-client0-role1b')
+        # role should not be re-created
+        self.assertEqual(role_a["id"], role_b["id"])
         # role attributes
         role_min = copy(role_b)
         role_min.pop("id")
@@ -491,3 +495,28 @@ class TestClientRoleResource(TestCaseBase):
         self.assertEqual(expected_role, role_min)
 
         # modify something
+        #
+        # hahaha, list endpoint cannot be used to get exactly one objects
+        # client0_roles_api.update_rmw(role_a["id"], {"description": 'ci0-client0-role1b-desc-NEW'})
+        #
+        data = client0_roles_api.findFirstByKV("name", 'ci0-client0-role1b')
+        data.update({"description": 'ci0-client0-role1b-desc-NEW'})
+        client0_roles_api.update(role_a["id"], data)
+        role_c = client0_roles_api.findFirstByKV("name", 'ci0-client0-role1b')
+        self.assertEqual(role_a["id"], role_c["id"])
+        self.assertEqual("ci0-client0-role1b-desc-NEW", role_c["description"])
+        # .publish must revert change
+        creation_state = role_resource.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
+        roles_d = client0_roles_api.all(params=dict(briefRepresentation=False))
+        self.assertEqual(
+            ['ci0-client0-role0', 'ci0-client0-role1b'],
+            sorted([role["name"] for role in roles_d])
+        )
+        role_d = find_in_list(roles_d, name='ci0-client0-role1b')
+        # role should not be re-created
+        self.assertEqual(role_a["id"], role_d["id"])
+        # role attributes
+        role_min = copy(role_d)
+        role_min.pop("id")
+        role_min.pop("containerId")
+        self.assertEqual(expected_role, role_min)

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -475,7 +475,7 @@ class TestClientRoleResource(TestCaseBase):
 
         # publish data - 2nd time, idempotence
         creation_state = role_resource.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
-        # self.assertFalse(creation_state)   # TODO briefRepresentation=False is needed. Fix kcapi?
+        self.assertFalse(creation_state)
         roles_b = client0_roles_api.all(params=dict(briefRepresentation=False))
         self.assertEqual(
             ['ci0-client0-role0', 'ci0-client0-role1b'],

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -373,7 +373,9 @@ class TestClientRoleResourceManager(TestCaseBase):
 
         # publish same data again - idempotence
         creation_state = manager.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
-        self.assertTrue(creation_state)  # TODO should be false; but composites are missing
+        # TODO should be false; but composites are missing
+        # As ClientRoleResource just throws away .composites, we get idempotence, but data on server is WRONG!!!
+        self.assertFalse(creation_state)
         roles = client0_roles_api.all()
         self.assertEqual(
             our_roles_names,


### PR DESCRIPTION
Client roles are imported. Attributes are included, idempotence is respected. Composites are just ignored ATM.