### PR TITLE
Impolement composite client roles

### DIFF
--- a/kcloader/resource/client_resource.py
+++ b/kcloader/resource/client_resource.py
@@ -143,6 +143,8 @@ class ClientRoleResource(SingleResource):
         for oo in [obj1, obj2]:
             oo.pop("id", None)
             oo.pop("containerId", None)
+            # composites - ignore them, or convert one to hava containerId or containerName in both
+            oo.pop("composites", None)
         return obj1 == obj2
 
 

--- a/kcloader/resource/client_resource.py
+++ b/kcloader/resource/client_resource.py
@@ -14,6 +14,10 @@ logger = logging.getLogger(__name__)
 
 
 class ClientRoleResource(SingleResource):
+    """
+    The ClientRoleResource creates/updates client role.
+    It also creates/updates/deletes role composites - that part should be in some Manager class (but is not).
+    """
     def __init__(
             self,
             resource: dict,

--- a/kcloader/resource/client_resource.py
+++ b/kcloader/resource/client_resource.py
@@ -101,7 +101,6 @@ class ClientRoleResource(SingleResource):
                 this_role_composites_api.remove(None, [role_obj]).isOk()
                 creation_state = True
 
-
         return creation_state
 
     def _get_composites_docs(

--- a/kcloader/resource/resource.py
+++ b/kcloader/resource/resource.py
@@ -40,8 +40,8 @@ class Resource:
     def publish(self, body):
         return ResourcePublisher(self.key, body).publish(self._resource_api)
 
-    def publish_object(self, single_resource):
-        return ResourcePublisher(self.key, single_resource.body, single_resource).publish(self._resource_api)
+    def publish_object(self, body, single_resource):
+        return ResourcePublisher(self.key, body, single_resource).publish(self._resource_api)
 
     def remove(self, body):
         id = self.get_resource_id(body)

--- a/kcloader/resource/role_resource.py
+++ b/kcloader/resource/role_resource.py
@@ -19,6 +19,8 @@ def find_sub_role(self, clients, realm_roles, clients_roles, sub_role):
             # I'm not able to reproduce locally.
             logger.error(f"client clientId={sub_role['containerName']} not found")
             return None
+        # TODO move also this out, to cache/reuse API responses
+        # But how often is data for _all_ clients needed? Lazy loading would be nice.
         some_client_roles_api = clients_api.get_child(clients_api, some_client["id"], "roles")
         some_client_roles = some_client_roles_api.all()  # TODO cache this response
         role = find_in_list(some_client_roles, name=sub_role["name"])
@@ -47,7 +49,7 @@ class RoleResource(SingleResource):
 
         super().publish()
         # second publish for RTH SSO 7.4 to load also .attributes
-        super().publish()
+        super().publish()  # not needed with kcapi>=1.0.37
 
         if body_orig:
                 self.body["composites"] = body_orig

--- a/main.py
+++ b/main.py
@@ -171,6 +171,10 @@ def main(args):
     client_manager = ClientManager(keycloak_api, realm_name, datadir)
     creation_state = client_manager.publish()
 
+    #---------------------------------
+    # Pass 2, resolve circular dependencies
+    creation_state = client_manager.publish()
+
     return
 
     # User federations

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -426,11 +426,15 @@ class TestClientRoleResource(TestCaseBase):
         })
 
         self.clients_api = testbed.kc.build("clients", testbed.REALM)
+        self.realm_roles_api = testbed.kc.build("roles", testbed.REALM)
+        self.roles_by_id_api = testbed.kc.build("roles-by-id", testbed.REALM)
         # check clean start
         assert len(self.clients_api.all()) == 6  # 6 default clients
+        assert len(self.realm_roles_api.all()) == 2  # 2 default realm roles (for master realm - 4)
 
         # this creates "empty" "ci0-client0-role0"
         self.client0_resource.publish_self()
+        self.client0 = self.clients_api.findFirstByKV("clientId", self.client0_clientId)
 
     def test_publish_without_composites(self):
         # testbed = self.testbed
@@ -439,17 +443,21 @@ class TestClientRoleResource(TestCaseBase):
         client0_roles_api = self.clients_api.roles(client_query)
         # TODO test with simple ci0-client-0.json and with some composite role
         role_filepath = os.path.join(self.testbed.DATADIR, "ci0-realm/clients/client-0/roles/ci0-client0-role1b.json")
-        expected_role = json.load(open(role_filepath))
+        with open(role_filepath) as ff:
+            expected_role = json.load(ff)
         # make sure we do test "attributes". They are just easy to miss.
         self.assertEqual({'ci0-client0-role1b-key0': ['ci0-client0-role1b-value0']}, expected_role["attributes"])
 
         role_resource = ClientRoleResource({
-            'path': role_filepath,
-            'keycloak_api': self.testbed.kc,
-            'realm': self.testbed.REALM,
-            'datadir': self.testbed.DATADIR,
-            'client_roles_api': client0_roles_api,
-        })
+                'path': role_filepath,
+                'keycloak_api': self.testbed.kc,
+                'realm': self.testbed.REALM,
+                'datadir': self.testbed.DATADIR,
+            },
+            clientId=self.client0_clientId,
+            client_id=self.client0["id"],
+            client_roles_api=client0_roles_api,
+        )
 
         # check initial state
         # "empty" ci0-client0-role0 is created when we import ci0-client-0.json
@@ -507,6 +515,162 @@ class TestClientRoleResource(TestCaseBase):
             sorted([role["name"] for role in roles_d])
         )
         role_d = find_in_list(roles_d, name='ci0-client0-role1b')
+        # role should not be re-created
+        self.assertEqual(role_a["id"], role_d["id"])
+        # role attributes
+        role_min = copy(role_d)
+        role_min.pop("id")
+        role_min.pop("containerId")
+        self.assertEqual(expected_role, role_min)
+
+    def test_publish_with_composites(self):
+        self.maxDiff = None
+        # testbed = self.testbed
+        # client0 = self.clients_api.findFirstByKV("clientId", self.client0_clientId)
+        client_query = {'key': 'clientId', 'value': self.client0_clientId}
+        client0_roles_api = self.clients_api.roles(client_query)
+        roles_by_id_api = self.roles_by_id_api
+        # TODO test with simple ci0-client-0.json and with some composite role
+        role_filepath = os.path.join(self.testbed.DATADIR, "ci0-realm/clients/client-0/roles/ci0-client0-role1.json")
+        with open(role_filepath) as ff:
+            expected_role = json.load(ff)
+            # API does not include composites into API response.
+            # kcfetcher is "artificially" adding "composites" into role .json file.
+            expected_role_composites = expected_role.pop("composites")
+        # make sure we do test "attributes". They are just easy to miss.
+        self.assertEqual({'ci0-client0-role1-key0': ['ci0-client0-role1-value0']}, expected_role["attributes"])
+        # make sure composites are complex enough
+        self.assertEqual([
+                {
+                    "clientRole": True,
+                    "containerName": "ci0-client-0",
+                    "name": "ci0-client0-role1a"
+                },
+                {
+                    "clientRole": True,
+                    "containerName": "ci0-client-0",
+                    "name": "ci0-client0-role1b"
+                },
+                {
+                    "clientRole": False,
+                    "containerName": "ci0-realm",
+                    "name": "ci0-role-1a"
+                }
+            ],
+            expected_role_composites
+        )
+
+        role_resource = ClientRoleResource({
+            'path': role_filepath,
+            'keycloak_api': self.testbed.kc,
+            'realm': self.testbed.REALM,
+            'datadir': self.testbed.DATADIR,
+            },
+            clientId=self.client0_clientId,
+            client_id=self.client0["id"],
+            client_roles_api=client0_roles_api,
+        )
+
+        # check initial state
+        # "empty" ci0-client0-role0 is created when we import ci0-client-0.json
+        roles = client0_roles_api.all()
+        self.assertEqual(["ci0-client0-role0"], [role["name"] for role in roles])
+
+        # Fixup - create required sub-roles first
+        self.realm_roles_api.create(dict(name="ci0-role-1a", description="ci0-role-1a---injected-by-CI-test"))
+        assert len(self.realm_roles_api.all()) == 2 + 1  # 2 default realm roles
+        client0_roles_api.create(dict(name="ci0-client0-role1a", description="ci0-client0-role1a---injected-by-CI-test"))
+        client0_roles_api.create(dict(name="ci0-client0-role1b", description="ci0-client0-role1b---injected-by-CI-test"))
+        assert len(client0_roles_api.all()) == 1 + 2  # the "empty" ci0-client0-role0 is created when client is createddf
+
+        expected_composite_role_names = ["ci0-client0-role1a", "ci0-client0-role1b", "ci0-role-1a"]
+        realm = self.testbed.master_realm.get_one(self.testbed.realm)
+        expected_composites_role_container_ids = sorted([self.client0["id"], self.client0["id"], realm["id"]])
+
+        # END prepare
+        # -----------------------------------------
+
+        # publish data - 1st time
+        creation_state = role_resource.publish()
+        self.assertTrue(creation_state)
+        roles_a = client0_roles_api.all()
+        self.assertEqual(
+            ['ci0-client0-role0', 'ci0-client0-role1','ci0-client0-role1a', 'ci0-client0-role1b'],
+            sorted([role["name"] for role in roles_a])
+        )
+        #
+        # .composites are returned only by role-by-id API?
+        role_a_temp = find_in_list(roles_a, name='ci0-client0-role1')
+        role_id = role_a_temp["id"]
+        this_role_composites_api = roles_by_id_api.get_child(roles_by_id_api, role_id, "composites")
+        role_a = roles_by_id_api.get_one(role_id)
+        #
+        # role attributes
+        role_min = copy(role_a)
+        role_min.pop("id")
+        role_min.pop("containerId")
+        self.assertEqual(expected_role, role_min)
+        # check subroles
+        composites = this_role_composites_api.all()
+        composite_role_names = sorted([obj["name"] for obj in composites])
+        composites_role_container_ids = sorted([obj["containerId"] for obj in composites])
+        self.assertEqual(
+            expected_composite_role_names,
+            composite_role_names,
+        )
+        self.assertEqual(
+            expected_composites_role_container_ids,
+            composites_role_container_ids,
+        )
+
+        # publish data - 2nd time, idempotence
+        creation_state = role_resource.publish()
+        self.assertFalse(creation_state)
+        roles_b = client0_roles_api.all()
+        self.assertEqual(
+            ['ci0-client0-role0', 'ci0-client0-role1', 'ci0-client0-role1a', 'ci0-client0-role1b'],
+            sorted([role["name"] for role in roles_b])
+        )
+        role_b = find_in_list(roles_b, name='ci0-client0-role1')
+        # role should not be re-created
+        self.assertEqual(role_a["id"], role_b["id"])
+        # role attributes
+        role_min = copy(role_b)
+        role_min.pop("id")
+        role_min.pop("containerId")
+        self.assertEqual(expected_role, role_min)
+        # check subroles
+        composites = this_role_composites_api.all()
+        composite_role_names = sorted([obj["name"] for obj in composites])
+        composites_role_container_ids = sorted([obj["containerId"] for obj in composites])
+        self.assertEqual(
+            expected_composite_role_names,
+            composite_role_names,
+        )
+        self.assertEqual(
+            expected_composites_role_container_ids,
+            composites_role_container_ids,
+        )
+
+        # modify something
+        #
+        # hahaha, list endpoint cannot be used to get exactly one objects
+        # client0_roles_api.update_rmw(role_a["id"], {"description": 'ci0-client0-role1b-desc-NEW'})
+        #
+        data = client0_roles_api.findFirstByKV("name", 'ci0-client0-role1')
+        data.update({"description": 'ci0-client0-role1b-desc-NEW'})
+        client0_roles_api.update(role_a["id"], data)
+        role_c = client0_roles_api.findFirstByKV("name", 'ci0-client0-role1')
+        self.assertEqual(role_a["id"], role_c["id"])
+        self.assertEqual("ci0-client0-role1b-desc-NEW", role_c["description"])
+        # .publish must revert change
+        creation_state = role_resource.publish()
+        roles_d = client0_roles_api.all()
+        self.assertEqual(
+            ['ci0-client0-role0', 'ci0-client0-role1', 'ci0-client0-role1a', 'ci0-client0-role1b'],
+            sorted([role["name"] for role in roles_d])
+        )
+        role_d = find_in_list(roles_d, name='ci0-client0-role1')
         # role should not be re-created
         self.assertEqual(role_a["id"], role_d["id"])
         # role attributes

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -626,7 +626,6 @@ class TestClientRoleResource(TestCaseBase):
         role_id = role_a["id"]
         this_role_composites_api = roles_by_id_api.get_child(roles_by_id_api, role_id, "composites")
         _check_state()
-
         # publish data - 2nd time, idempotence
         creation_state = role_resource.publish()
         self.assertFalse(creation_state)
@@ -644,6 +643,9 @@ class TestClientRoleResource(TestCaseBase):
         creation_state = role_resource.publish()
         self.assertTrue(creation_state)
         _check_state()
+        creation_state = role_resource.publish()
+        self.assertFalse(creation_state)
+        _check_state()
 
         # ------------------------------------------------------------------------
         # modify something - add one sub-role
@@ -660,6 +662,9 @@ class TestClientRoleResource(TestCaseBase):
         creation_state = role_resource.publish()
         self.assertTrue(creation_state)
         _check_state()
+        creation_state = role_resource.publish()
+        self.assertFalse(creation_state)
+        _check_state()
 
         # ------------------------------------------------------------------------
         # modify something - remove one sub-role
@@ -675,4 +680,7 @@ class TestClientRoleResource(TestCaseBase):
         # .publish must revert change
         creation_state = role_resource.publish()
         self.assertTrue(creation_state)
+        _check_state()
+        creation_state = role_resource.publish()
+        self.assertFalse(creation_state)
         _check_state()

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -684,3 +684,10 @@ class TestClientRoleResource(TestCaseBase):
         creation_state = role_resource.publish()
         self.assertFalse(creation_state)
         _check_state()
+
+        # ------------------------------------------------------------------------
+        # publish composite role, with include_composite=False should not destroy existing composites
+        # The composites should only remain unmodified.
+        creation_state = role_resource.publish(include_composite=False)
+        self.assertFalse(creation_state)
+        _check_state()

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -432,13 +432,7 @@ class TestClientRoleResource(TestCaseBase):
         # this creates "empty" "ci0-client0-role0"
         self.client0_resource.publish_self()
 
-    def test_publish(self):
-        our_roles_names = sorted([
-            "ci0-client0-role0",
-            "ci0-client0-role1",
-            "ci0-client0-role1a",
-            "ci0-client0-role1b",
-        ])
+    def test_publish_without_composites(self):
         # testbed = self.testbed
         # client0 = self.clients_api.findFirstByKV("clientId", self.client0_clientId)
         client_query = {'key': 'clientId', 'value': self.client0_clientId}
@@ -465,7 +459,7 @@ class TestClientRoleResource(TestCaseBase):
         # publish data - 1st time
         creation_state = role_resource.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
         self.assertTrue(creation_state)
-        roles_a = client0_roles_api.all(params=dict(briefRepresentation=False))
+        roles_a = client0_roles_api.all()
         self.assertEqual(
             ['ci0-client0-role0', 'ci0-client0-role1b'],
             sorted([role["name"] for role in roles_a])
@@ -480,7 +474,7 @@ class TestClientRoleResource(TestCaseBase):
         # publish data - 2nd time, idempotence
         creation_state = role_resource.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
         self.assertFalse(creation_state)
-        roles_b = client0_roles_api.all(params=dict(briefRepresentation=False))
+        roles_b = client0_roles_api.all()
         self.assertEqual(
             ['ci0-client0-role0', 'ci0-client0-role1b'],
             sorted([role["name"] for role in roles_b])
@@ -507,7 +501,7 @@ class TestClientRoleResource(TestCaseBase):
         self.assertEqual("ci0-client0-role1b-desc-NEW", role_c["description"])
         # .publish must revert change
         creation_state = role_resource.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
-        roles_d = client0_roles_api.all(params=dict(briefRepresentation=False))
+        roles_d = client0_roles_api.all()
         self.assertEqual(
             ['ci0-client0-role0', 'ci0-client0-role1b'],
             sorted([role["name"] for role in roles_d])

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -362,7 +362,7 @@ class TestClientRoleResourceManager(TestCaseBase):
         self.assertEqual([], delete_objs)
 
         # publish data - 1st time
-        creation_state = manager.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
+        creation_state = manager.publish(include_composite=False)
         self.assertTrue(creation_state)
         roles = client0_roles_api.all()
         self.assertEqual(
@@ -375,10 +375,9 @@ class TestClientRoleResourceManager(TestCaseBase):
         self.assertEqual([], delete_objs)
 
         # publish same data again - idempotence
-        creation_state = manager.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
-        # TODO should be false; but composites are missing
-        # As ClientRoleResource just throws away .composites, we get idempotence, but data on server is WRONG!!!
-        self.assertFalse(creation_state)
+        creation_state = manager.publish(include_composite=False)
+        # TODO should be false; but one composite (realm sub-role) is missing
+        self.assertTrue(creation_state)
         roles = client0_roles_api.all()
         self.assertEqual(
             our_roles_names,
@@ -404,7 +403,7 @@ class TestClientRoleResourceManager(TestCaseBase):
         self.assertEqual(['ci0-client0-role-x-to-be-deleted'], delete_ids)
 
         # check extra role is deleted
-        creation_state = manager.publish(include_composite=False)  # TODO extend CI test also with include_composite=True case
+        creation_state = manager.publish(include_composite=False)
         self.assertTrue(creation_state)
         roles = client0_roles_api.all()
         self.assertEqual(4, len(roles))

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -341,10 +341,13 @@ class TestClientRoleResourceManager(TestCaseBase):
         # client0 = self.clients_api.findFirstByKV("clientId", self.client0_clientId)
         client_query = {'key': 'clientId', 'value': self.client0_clientId}
         client0_roles_api = self.clients_api.roles(client_query)
+        client0 = self.clients_api.findFirstByKV("clientId", self.client0_clientId)
 
         manager = ClientRoleManager(
             self.testbed.kc, self.testbed.REALM, self.testbed.DATADIR,
-            clientId=self.client0_clientId, client_filepath=os.path.join(self.testbed.DATADIR, "ci0-realm/clients/client-0/ci0-client-0.json"),
+            clientId=self.client0_clientId,
+            client_id=client0["id"],
+            client_filepath=os.path.join(self.testbed.DATADIR, "ci0-realm/clients/client-0/ci0-client-0.json"),
         )
 
         # check initial state

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -630,8 +630,7 @@ class TestClientRoleResource(TestCaseBase):
 
         # publish data - 2nd time, idempotence
         creation_state = role_resource.publish()
-#        self.assertFalse(creation_state)
-        self.assertTrue(creation_state)
+        self.assertFalse(creation_state)
         _check_state()
 
         # ------------------------------------------------------------------------


### PR DESCRIPTION
Client roles composites are now loaded. Code requires 2 passes.

In first pass one all simple roles are created as expected. A composite role is created as simple roles, because required composites might not be present. If composite role already exists, it remain composite.

In second pass composite role composites are setup.