### PR TITLE
Fix for tag 0.0.5

### DIFF
--- a/kcloader/resource/client_resource.py
+++ b/kcloader/resource/client_resource.py
@@ -392,9 +392,9 @@ class SingleClientResource(SingleResource):
 
         return state
 
-    def publish(self):
+    def publish(self, *, include_composite=True):
         state = self.publish_self()
-        state_roles = self.client_role_manager.publish(include_composite=False)
+        state_roles = self.client_role_manager.publish(include_composite=include_composite)
         state_scopes = self.publish_scopes()
         return any([state, state_roles, state_scopes])
 
@@ -473,9 +473,9 @@ class ClientManager:
         object_filepaths = [fp for fp in object_filepaths if not fp.endswith("/scope-mappings.json")]
         return object_filepaths
 
-    def publish(self):
+    def publish(self, *, include_composite=True):
         create_ids, delete_objs = self._difference_ids()
-        status_resources = [resource.publish() for resource in self.resources]
+        status_resources = [resource.publish(include_composite=include_composite) for resource in self.resources]
         status_deleted = False
         for delete_obj in delete_objs:
             delete_id = delete_obj[self._resource_delete_id]

--- a/kcloader/resource/client_resource.py
+++ b/kcloader/resource/client_resource.py
@@ -95,6 +95,10 @@ class ClientRoleResource(SingleResource):
             sub_role = find_sub_role(self, clients, realm_roles, clients_roles=None, sub_role=sub_role_doc)
             if not sub_role:
                 logger.error(f"sub_role {sub_role_doc} not found")
+                # Either ignore or crash
+                # For now, ignore.
+                # TODO - code should crash - on second pass, all subroles should be present.
+                continue
             this_role_composites_api.create([sub_role]).isOk()
             creation_state = True
 

--- a/main.py
+++ b/main.py
@@ -169,9 +169,9 @@ def main(args):
 
     # load clients
     client_manager = ClientManager(keycloak_api, realm_name, datadir)
-    creation_state = client_manager.publish()
+    creation_state = client_manager.publish(include_composite=False)
 
-    #---------------------------------
+    # ---------------------------------
     # Pass 2, resolve circular dependencies
     creation_state = client_manager.publish()
 

--- a/test/kcloader/resource/test_client_resource.py
+++ b/test/kcloader/resource/test_client_resource.py
@@ -144,7 +144,8 @@ class TestClientResource(TestCaseBase):
             self.assertEqual(client_c, client_c | expected_client0)
         self.assertEqual('ci0-client-0-desc', clients_api.get_one(client_a["id"])['description'])
 
-    def test_publish(self):
+    def test_publish_without_comnposites(self):
+        # TODO test also .publish with include_composite=True
         self.maxDiff = None
         expected_role_names = [
             'ci0-client0-role0',
@@ -169,7 +170,7 @@ class TestClientResource(TestCaseBase):
         self.assertEqual(len(clients_all), default_client_count)
 
         # create client
-        creation_state = client0_resource.publish()
+        creation_state = client0_resource.publish(include_composite=False)
         self.assertTrue(creation_state)
         # check objects are created
         clients_all = clients_api.all()
@@ -207,7 +208,7 @@ class TestClientResource(TestCaseBase):
             expected_client0_b.pop("defaultRoles")
 
         # publish same data again - idempotence
-        creation_state = client0_resource.publish()
+        creation_state = client0_resource.publish(include_composite=False)
         self.assertTrue(creation_state)  # TODO - should be False if defaultClientScopes would contain ci0-client-scope
         # check content is not modified
         clients_all = clients_api.all()
@@ -259,7 +260,7 @@ class TestClientResourceManager(TestCaseBase):
         self.assertEqual([], delete_ids)
 
         # publish data - 1st time
-        creation_state = manager.publish()
+        creation_state = manager.publish(include_composite=False)
         self.assertTrue(creation_state)
         clients_all = clients_api.all()
         self.assertEqual(
@@ -272,7 +273,7 @@ class TestClientResourceManager(TestCaseBase):
         self.assertEqual([], delete_objs)
 
         # publish same data again - idempotence
-        creation_state = manager.publish()
+        creation_state = manager.publish(include_composite=False)
         self.assertTrue(creation_state)  # TODO should be false
         clients_all = clients_api.all()
         self.assertEqual(
@@ -300,8 +301,8 @@ class TestClientResourceManager(TestCaseBase):
         self.assertEqual([], create_ids)
         self.assertEqual(['ci0-client-x-to-be-deleted'], delete_ids)
 
-        # check extra IdP is deleted
-        creation_state = manager.publish()
+        # check extra client is deleted
+        creation_state = manager.publish(include_composite=False)
         self.assertTrue(creation_state)
         clients_all = clients_api.all()
         self.assertEqual(


### PR DESCRIPTION
CI test for client roles updated.

Temporal workaround for missing realm roles - do not crash, realm roles are missing, because they are not yet imported.