### PR TITLE
Import of user federation objects

### DIFF
--- a/kcloader/resource/__init__.py
+++ b/kcloader/resource/__init__.py
@@ -13,7 +13,7 @@ from .client_scope_resource import ClientScopeResource, ClientScopeScopeMappings
 from .default_client_scope_resource import DefaultDefaultClientScopeManager, DefaultOptionalClientScopeManager
 from .identity_provider_resource import IdentityProviderResource, IdentityProviderMapperResource
 from .identity_provider_resource import IdentityProviderManager, IdentityProviderMapperManager
-from .user_federation_resource import UserFederationResource
+from .user_federation_resource import UserFederationResource, UserFederationManager
 from .realm_resource import RealmResource
 
 from .many_resources import ManyResources, MultipleResourceInFolders
@@ -31,6 +31,7 @@ __all__ = [
     IdentityProviderResource,
     IdentityProviderMapperResource,
     UserFederationResource,
+    UserFederationManager,
 
     ManyResources,
     MultipleResourceInFolders,

--- a/kcloader/resource/user_federation_resource.py
+++ b/kcloader/resource/user_federation_resource.py
@@ -1,26 +1,237 @@
-import json
-import logging
 from copy import copy
+from glob import glob
 
+import logging
+import os
 import kcapi
 
 from kcloader.resource import SingleResource
 from kcloader.tools import find_in_list
-from kcloader.tools import read_from_json, remove_unnecessary_fields
-from kcloader.resource import Resource
+from kcloader.tools import read_from_json
 
 logger = logging.getLogger(__name__)
 
 
 class UserFederationResource(SingleResource):
+    _resource_name = 'components'
+    _resource_id = 'name'
+    _resource_delete_id = 'id'
+
+    def __init__(self, resource):
+        super().__init__({
+            'name': self._resource_name,
+            'id': self._resource_id,
+            **resource,
+        })
+        self.datadir = resource['datadir']
+
+    def _get_query_params(self, parent):
+        params = {
+            "parent": parent["id"],
+            "type": "org.keycloak.storage.UserStorageProvider"
+        }
+        return params
+
+    def find_created_object(self, parent: dict, body: dict):
+        # This part can be optimized if we first create/update all federations in first pass, and then
+        # update mapping is second pass
+        #
+        # In that case we would be able to get ID/s for all object on one REST call, and then just
+        # do mathing in memory. Now we get whole list for each element. Optimization is not there
+        # because this would make code less readable.
+        params = self._get_query_params(parent)
+        listed = self.keycloak_api.build(self._resource_name, self.realm_name).all(params)
+        match = next((x for x in listed if x[self._resource_id]==body[self._resource_id]), None)
+        return match
+
+    def publish_self(self):
+        return super().publish()
+
+    def publish(self, parent: dict):
+        del self.body["parentName"]
+        self.body["parentId"] = parent["id"]
+
+        status_self = self.publish_self()
+
+        match = self.find_created_object(parent, self.body)
+        mapper_manager = UserFederationMapperManager(self.keycloak_api, self.realm_name, self.datadir, parent=match)
+
+        status_mappers = mapper_manager.publish()
+        return any([status_self, status_mappers])
+
+
+##### NEW
+class UserFederationManager:
+    _resource_name = UserFederationResource._resource_name
+    _resource_id = UserFederationResource._resource_id
+    _resource_delete_id = UserFederationResource._resource_delete_id
+
+    @classmethod
+    def _get_path(cls, datadir: str, realm: str):
+        return glob(os.path.join(datadir, f"{realm}/user-federations/*/*.json"))
+
+
+    def __init__(self, keycloak_api: kcapi.sso.Keycloak, realm: str, datadir: str):
+        self.keycloak_api = keycloak_api
+        self.realm = realm
+        self.datadir = datadir
+
+        self.parent = self.keycloak_api.admin().get_one(self.realm)
+        self.resource_api = self.keycloak_api.build(self._resource_name, self.realm)
+
+        idp_filepaths = self._get_path(datadir, realm)
+        self.resources = [
+            UserFederationResource({
+                'path': idp_filepath,
+                'keycloak_api': keycloak_api,
+                'realm': realm,
+                'datadir': datadir,
+            })
+            for idp_filepath in idp_filepaths
+        ]
+
     def publish(self):
-        # revert realm parentName back to parentId
-        master_realm_api = self.keycloak_api.admin()
-        realms = master_realm_api.all()
+        create_ids, delete_objs = self._difference_ids()
+        status_resources = [resource.publish(self.parent) for resource in self.resources]
+        status_deleted = False
+        for obj in delete_objs:
+            self.resource_api.remove(obj[self._resource_delete_id]).isOk()
+            status_deleted = True
+        return any(status_resources + [status_deleted])
+
+    def _get_query_params(self):
+        params = {
+            "parent": self.parent["id"],
+            "type": "org.keycloak.storage.UserStorageProvider"
+        }
+        return params
+
+
+    def _difference_ids(self):
+        """
+        If item is present on server but missing in datadir, then it needs to be removed.
+        This function will return list of items that needs to be removed.
+        """
+        filepaths = self._get_path(self.datadir, self.realm)
+        file_docs = [read_from_json(filepath) for filepath in filepaths]
+        file_ids = [doc[self._resource_id] for doc in file_docs]
+        
+        params = self._get_query_params()
+        server_objs = self.resource_api.all(params)
+        
+        server_ids = [obj[self._resource_id] for obj in server_objs]
+        # remove objects that are on server, but missing in datadir
+        delete_ids = list(set(server_ids).difference(file_ids))
+        # create objects that are in datdir, but missing on server
+        create_ids = list(set(file_ids).difference(server_ids))
+        delete_objs = [obj for obj in server_objs if obj[self._resource_id] in delete_ids]
+        return create_ids, delete_objs
+
+
+class UserFederationProviderMapperResource(SingleResource):
+    _resource_name = 'components'
+    _resource_id = 'name'
+    _resource_delete_id = 'id'
+
+    def __init__(self, resource):
+        super().__init__({
+            "name": "components",
+            "id": "name",
+            **resource,
+        })
+
+    def _get_query_params(self, parent):
+            params = {
+                "parent": parent["id"],
+                "type": "org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
+            }
+            return params
+
+    def publish(self, parent):
+        providerType = self.body["providerType"]
+        if providerType != "org.keycloak.storage.ldap.mappers.LDAPStorageMapper":
+            raise Exception(f"Unknown user federation mapping type: {providerType}!")
+        mappers_api = self.resource.resource_api
+
+        params = self._get_query_params(parent)
+        mappers = mappers_api.all(params)
+        mapper_item = find_in_list(mappers, name=self.body[self._resource_id])
 
         body = copy(self.body)
-        realm_name = body.pop("parentName")
-        realm = find_in_list(realms, realm=realm_name)
-        body["parentId"] = realm["id"]
+        body["parentId"] = parent["id"]
+        
+        if not mapper_item:
+            mappers_api.create(body).isOk()
+            # was created
+            return True
+        body.update({"id": mapper_item["id"]})
+        if body == mapper_item:
+            # no change
+            return False
+        mappers_api.update(mapper_item["id"], body).isOk()
+        return True
 
-        return self.resource.publish(body)
+
+class UserFederationMapperManager:
+    _resource_name = UserFederationProviderMapperResource._resource_name
+    _resource_id = UserFederationProviderMapperResource._resource_id
+    _resource_delete_id = UserFederationProviderMapperResource._resource_delete_id
+
+    @classmethod
+    def _get_path(cls, datadir: str, realm: str, identifier: str):
+        return glob(os.path.join(datadir, f"{realm}/user-federations/{identifier}/mappers/*.json"))
+
+    def __init__(self, keycloak_api: kcapi.sso.Keycloak, realm: str, datadir: str,
+                 *, parent: dict):
+        self.parent = parent
+        self.keycloak_api = keycloak_api
+        self.realm = realm
+        self.datadir = datadir
+        self.resource_api = self.keycloak_api.build(self._resource_name, self.realm)
+
+        mappers_filepaths = self._get_path(datadir, realm, parent[self._resource_id])
+        self.resources = [
+            UserFederationProviderMapperResource({
+                'path': mappers_filepath,
+                'keycloak_api': keycloak_api,
+                'realm': realm,
+                'datadir': datadir,
+            })
+            for mappers_filepath in mappers_filepaths
+        ]
+
+    def publish(self):
+        create_ids, delete_objs = self._difference_ids()
+        status_resources = [resource.publish(self.parent) for resource in self.resources]
+        status_deleted = False
+        for obj in delete_objs:
+            self.resource_api.remove(obj[self._resource_delete_id])
+            status_deleted = True
+        return any(status_resources + [status_deleted])
+
+    def _get_query_params(self):
+            params = {
+                "parent": self.parent["id"],
+                "type": "org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
+            }
+            return params
+
+    def _difference_ids(self):
+        """
+        If item is present on server but missing in datadir, then it needs to be removed.
+        This function will return list of items that needs to be removed.
+        """
+        filepaths = self._get_path(self.datadir, self.realm, self.parent[self._resource_id])
+        file_docs = [read_from_json(filepath) for filepath in filepaths]
+        file_ids = [doc[self._resource_id] for doc in file_docs]
+
+        params = self._get_query_params()
+        server_objs = self.resource_api.all(params)
+
+        server_ids = [obj[self._resource_id] for obj in server_objs]
+        # remove objects that are on server, but missing in datadir
+        delete_ids = list(set(server_ids).difference(file_ids))
+        # create objects that are in datdir, but missing on server
+        create_ids = list(set(file_ids).difference(server_ids))
+        delete_objs = [obj for obj in server_objs if obj[self._resource_id] in delete_ids]
+        return create_ids, delete_objs

--- a/main.py
+++ b/main.py
@@ -14,7 +14,8 @@ from kcloader.resource import ResourcePublisher, ManyResources, SingleResource, 
     SingleClientResource, SingleCustomAuthenticationResource, ClientScopeResource, \
     IdentityProviderResource, IdentityProviderMapperResource, UserFederationResource, \
     RealmResource, ClientScopeManager, \
-    DefaultDefaultClientScopeManager, DefaultOptionalClientScopeManager
+    DefaultDefaultClientScopeManager, DefaultOptionalClientScopeManager, \
+    UserFederationManager
 from kcloader.resource import IdentityProviderManager, ClientManager, RealmRoleManager
 from kcloader.tools import read_from_json
 
@@ -180,6 +181,7 @@ def main(args):
             }).isOk()
 
     idp_manager = IdentityProviderManager(keycloak_api, realm_name, datadir)
+    uf_manager = UserFederationManager(keycloak_api, realm_name, datadir)
     realm_role_manager = RealmRoleManager(keycloak_api, realm_name, datadir)
     client_manager = ClientManager(keycloak_api, realm_name, datadir)
     client_scope_manager = ClientScopeManager(keycloak_api, realm_name, datadir)
@@ -187,6 +189,7 @@ def main(args):
     default_optional_client_scope_manager = DefaultOptionalClientScopeManager(keycloak_api, realm_name, datadir)
 
     creation_state = idp_manager.publish()
+    creation_state = uf_manager.publish()
     creation_state = realm_role_manager.publish(include_composite=False)
     creation_state = client_manager.publish(include_composite=False)
     # new client_scopes are not yet created, we need setup_new_links=False.

--- a/test/kcloader/resource/test_user_federation.py
+++ b/test/kcloader/resource/test_user_federation.py
@@ -1,0 +1,64 @@
+import os
+
+from kcloader.resource.user_federation_resource import UserFederationResource
+from ...helper import TestCaseBase
+
+
+class TestUserFederationResource(TestCaseBase):
+    def get_test_resource_a(self):
+        resource_filepath = os.path.join(self.testbed.DATADIR, f"{self.testbed.REALM}/user-federations/ci0-uf0-ldap/ci0-uf0-ldap.json")
+        return self.get_test_resource(resource_filepath)
+
+    def get_test_resource_b(self):
+        resource_filepath = os.path.join(self.testbed.DATADIR, f"{self.testbed.REALM}/user-federations/ci0-uf1-ldap/ci0-uf1-ldap.json")
+        return self.get_test_resource(resource_filepath)
+
+    def get_test_resource(self, resource_filepath):
+        resource = UserFederationResource({
+            'path': resource_filepath,
+            'keycloak_api': self.testbed.kc,
+            'realm': self.testbed.REALM,
+            'datadir': self.testbed.DATADIR,
+        })
+        return resource
+
+    def test_publish_empty(self):
+        realm_obj = self.testbed.kc.admin().get_one(self.testbed.REALM)
+        
+        resource = self.get_test_resource_a()
+        creation_state = resource.publish(realm_obj)
+        self.assertTrue(creation_state)
+
+    def test_publish_idenpotent(self):
+        realm_obj = self.testbed.kc.admin().get_one(self.testbed.REALM)
+        
+        resource = self.get_test_resource_a()
+        creation_state = resource.publish(realm_obj)
+        self.assertTrue(creation_state)
+
+        resource_update = self.get_test_resource_a()
+        update_state = resource_update.publish(realm_obj)
+        self.assertFalse(update_state)
+
+    def test_publish_update(self):
+        realm_obj = self.testbed.kc.admin().get_one(self.testbed.REALM)
+        
+        resource = self.get_test_resource_a()
+        creation_state = resource.publish(realm_obj)
+        self.assertTrue(creation_state)
+
+        resource_update = self.get_test_resource_a()
+        resource_update.body["config"]["enabled"] = ["false"]
+        update_state = resource_update.publish(realm_obj)
+        self.assertTrue(update_state)
+
+    def test_publish_different_obj(self):
+        realm_obj = self.testbed.kc.admin().get_one(self.testbed.REALM)
+        
+        resource = self.get_test_resource_a()
+        creation_state = resource.publish(realm_obj)
+        self.assertTrue(creation_state)
+
+        resource_b = self.get_test_resource_b()
+        update_state = resource_b.publish(realm_obj)
+        self.assertTrue(update_state)


### PR DESCRIPTION
We also update mappings, which are always of type LDAP since kerberos does not support user mappings.