### PR TITLE
Publish default client scopes

### DIFF
--- a/kcloader/resource/__init__.py
+++ b/kcloader/resource/__init__.py
@@ -10,7 +10,7 @@ from .client_scope_resource import ClientScopeResource, ClientScopeScopeMappings
     ClientScopeProtocolMapperResource, ClientScopeProtocolMapperManager, \
     ClientScopeScopeMappingsClientManager, ClientScopeScopeMappingsAllClientsManager, \
     ClientScopeManager
-from .default_client_scope_resource import DefaultDefaultClientScopeManager
+from .default_client_scope_resource import DefaultDefaultClientScopeManager, DefaultOptionalClientScopeManager
 from .identity_provider_resource import IdentityProviderResource, IdentityProviderMapperResource
 from .identity_provider_resource import IdentityProviderManager, IdentityProviderMapperManager
 from .user_federation_resource import UserFederationResource

--- a/kcloader/resource/__init__.py
+++ b/kcloader/resource/__init__.py
@@ -10,6 +10,7 @@ from .client_scope_resource import ClientScopeResource, ClientScopeScopeMappings
     ClientScopeProtocolMapperResource, ClientScopeProtocolMapperManager, \
     ClientScopeScopeMappingsClientManager, ClientScopeScopeMappingsAllClientsManager, \
     ClientScopeManager
+from .default_client_scope_resource import DefaultDefaultClientScopeManager
 from .identity_provider_resource import IdentityProviderResource, IdentityProviderMapperResource
 from .identity_provider_resource import IdentityProviderManager, IdentityProviderMapperManager
 from .user_federation_resource import UserFederationResource

--- a/kcloader/resource/default_client_scope_resource.py
+++ b/kcloader/resource/default_client_scope_resource.py
@@ -1,0 +1,61 @@
+import json
+import logging
+import os
+from copy import copy
+from glob import glob
+
+import kcapi
+from sortedcontainers import SortedDict
+
+from kcloader.resource import SingleResource
+from kcloader.tools import find_in_list, read_from_json
+from kcloader.resource.base_manager import BaseManager
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultDefaultClientScopeManager(BaseManager):
+    # https://172.17.0.2:8443/auth/admin/realms/ci0-realm/default-default-client-scopes/ee3a3fed-af78-4c04-b9d9-3fc1b614a0a2
+    _resource_name = "default-default-client-scopes"
+    _resource_id = "name"
+    _resource_delete_id = "id"
+    _resource_id_blacklist = []
+
+    def __init__(self, keycloak_api: kcapi.sso.Keycloak, realm: str, datadir: str):
+        """
+        requested_doc is like '["ci0-client-scope", "email", ...]'
+        """
+        super().__init__(keycloak_api, realm, datadir)
+        self.client_scopes_api = keycloak_api.build("client-scopes", realm)
+        ## self.realm_roles_api = keycloak_api.build("roles", realm)
+        self.resource_api = self._get_resource_api()
+
+        requested_doc = read_from_json(os.path.join(datadir, realm, "client-scopes/default/default-default-client-scopes.json"))
+        self.requested_doc = requested_doc
+
+    def publish(self):
+        create_ids, delete_objs = self._difference_ids()
+
+        # PUT to URL https://172.17.0.2:8443/auth/admin/realms/ci0-realm/default-default-client-scopes/ee3a3fed-af78-4c04-b9d9-3fc1b614a0a2
+        # payload like: {"realm":"ci0-realm","clientScopeId":"ee3a3fed-af78-4c04-b9d9-3fc1b614a0a2"}
+        status_created = False
+        client_scopes = self.client_scopes_api.all()
+        for create_id in create_ids:
+            client_scope = find_in_list(client_scopes, name=create_id)
+            create_obj = dict(
+                realm=self.realm,
+                clientScopeId=client_scope["id"],
+            )
+            self.resource_api.update(client_scope["id"], create_obj).isOk()
+            status_created = True
+
+        status_deleted = False
+        for delete_obj in delete_objs:
+            self.resource_api.remove(delete_obj["id"], None).isOk()
+            status_deleted = True
+
+        return any([status_created, status_deleted])
+
+    def _object_docs_ids(self):
+        # requested_doc contains only client-scope names
+        return self.requested_doc

--- a/kcloader/resource/default_client_scope_resource.py
+++ b/kcloader/resource/default_client_scope_resource.py
@@ -14,9 +14,9 @@ from kcloader.resource.base_manager import BaseManager
 logger = logging.getLogger(__name__)
 
 
-class DefaultDefaultClientScopeManager(BaseManager):
+class BaseDefaultClientScopeManager(BaseManager):
     # https://172.17.0.2:8443/auth/admin/realms/ci0-realm/default-default-client-scopes/ee3a3fed-af78-4c04-b9d9-3fc1b614a0a2
-    _resource_name = "default-default-client-scopes"
+    # _resource_name = "default-default-client-scopes"
     _resource_id = "name"
     _resource_delete_id = "id"
     _resource_id_blacklist = []
@@ -30,7 +30,8 @@ class DefaultDefaultClientScopeManager(BaseManager):
         ## self.realm_roles_api = keycloak_api.build("roles", realm)
         self.resource_api = self._get_resource_api()
 
-        requested_doc = read_from_json(os.path.join(datadir, realm, "client-scopes/default/default-default-client-scopes.json"))
+        requested_doc = read_from_json(os.path.join(datadir, realm, f"client-scopes/default/{self._resource_name}.json"))
+        self.requested_doc = requested_doc
         self.requested_doc = requested_doc
 
     def publish(self):
@@ -59,3 +60,11 @@ class DefaultDefaultClientScopeManager(BaseManager):
     def _object_docs_ids(self):
         # requested_doc contains only client-scope names
         return self.requested_doc
+
+
+class DefaultDefaultClientScopeManager(BaseDefaultClientScopeManager):
+    _resource_name = "default-default-client-scopes"
+
+
+class DefaultOptionalClientScopeManager(BaseDefaultClientScopeManager):
+    _resource_name = "default-optional-client-scopes"

--- a/main.py
+++ b/main.py
@@ -189,9 +189,10 @@ def main(args):
     creation_state = idp_manager.publish()
     creation_state = realm_role_manager.publish(include_composite=False)
     creation_state = client_manager.publish(include_composite=False)
+    # new client_scopes are not yet created, we need setup_new_links=False.
+    creation_state = default_default_client_scope_manager.publish(setup_new_links=False)
+    creation_state = default_optional_client_scope_manager.publish(setup_new_links=False)
     creation_state = client_scope_manager.publish(include_scope_mappings=False)
-    creation_state = default_default_client_scope_manager.publish()
-    creation_state = default_optional_client_scope_manager.publish()
 
     # ---------------------------------
     # Pass 2, resolve circular dependencies
@@ -199,6 +200,8 @@ def main(args):
     creation_state = realm_role_manager.publish(include_composite=True)
     creation_state = client_manager.publish(include_composite=True)
     creation_state = client_scope_manager.publish(include_scope_mappings=True)
+    creation_state = default_default_client_scope_manager.publish(setup_new_links=True)
+    creation_state = default_optional_client_scope_manager.publish(setup_new_links=True)
 
     return
 

--- a/main.py
+++ b/main.py
@@ -151,16 +151,33 @@ def main(args):
     realm_res.publish(minimal_representation=True)
 
     # load all auth flows
-    auth_flow_filepaths = glob(os.path.join(datadir, f"{realm_name}/authentication/flows/*/*.json"))
-    for auth_flow_filepath in auth_flow_filepaths:
-        auth_flow_res = SingleCustomAuthenticationResource({
-            'path': auth_flow_filepath,
-            # 'name': 'authentication',
-            # 'id': 'alias',
-            'keycloak_api': keycloak_api,
-            'realm': realm_name,
-        })
-        creation_state = auth_flow_res.publish()
+    if 0:
+        # refactoring needed
+        auth_flow_filepaths = glob(os.path.join(datadir, f"{realm_name}/authentication/flows/*/*.json"))
+        for auth_flow_filepath in auth_flow_filepaths:
+            auth_flow_res = SingleCustomAuthenticationResource({
+                'path': auth_flow_filepath,
+                # 'name': 'authentication',
+                # 'id': 'alias',
+                'keycloak_api': keycloak_api,
+                'realm': realm_name,
+            })
+            creation_state = auth_flow_res.publish()
+    else:
+        # temporal workaround
+        auth_flow_alias = "ci0-auth-flow-generic"  # used for realm resetCredentialsFlow
+        logger.error(f"Creating a fake authentication flow {auth_flow_alias}")
+        auth_flow_api = keycloak_api.build("authentication", realm_name)
+        auth_flows = auth_flow_api.all()
+        auth_flow_aliases = [auth_flow["alias"] for auth_flow in auth_flows]
+        if auth_flow_alias not in auth_flow_aliases:
+            auth_flow_api.create({
+                "alias": auth_flow_alias,
+                "providerId": "basic-flow",
+                "description": auth_flow_alias + "---TEMP-INJECTED",
+                "topLevel": True,
+                "builtIn": False
+            }).isOk()
 
     idp_manager = IdentityProviderManager(keycloak_api, realm_name, datadir)
     realm_role_manager = RealmRoleManager(keycloak_api, realm_name, datadir)

--- a/main.py
+++ b/main.py
@@ -13,7 +13,8 @@ from kcapi.ie import AuthenticationFlowsImporter
 from kcloader.resource import ResourcePublisher, ManyResources, SingleResource, \
     SingleClientResource, SingleCustomAuthenticationResource, ClientScopeResource, \
     IdentityProviderResource, IdentityProviderMapperResource, UserFederationResource, \
-    RealmResource, ClientScopeManager
+    RealmResource, ClientScopeManager, \
+    DefaultDefaultClientScopeManager, DefaultOptionalClientScopeManager
 from kcloader.resource import IdentityProviderManager, ClientManager, RealmRoleManager
 from kcloader.tools import read_from_json
 
@@ -165,11 +166,15 @@ def main(args):
     realm_role_manager = RealmRoleManager(keycloak_api, realm_name, datadir)
     client_manager = ClientManager(keycloak_api, realm_name, datadir)
     client_scope_manager = ClientScopeManager(keycloak_api, realm_name, datadir)
+    default_default_client_scope_manager = DefaultDefaultClientScopeManager(keycloak_api, realm_name, datadir)
+    default_optional_client_scope_manager = DefaultOptionalClientScopeManager(keycloak_api, realm_name, datadir)
 
     creation_state = idp_manager.publish()
     creation_state = realm_role_manager.publish(include_composite=False)
     creation_state = client_manager.publish(include_composite=False)
     creation_state = client_scope_manager.publish(include_scope_mappings=False)
+    creation_state = default_default_client_scope_manager.publish()
+    creation_state = default_optional_client_scope_manager.publish()
 
     # ---------------------------------
     # Pass 2, resolve circular dependencies

--- a/test/integration/test_main_client_scopes.py
+++ b/test/integration/test_main_client_scopes.py
@@ -1,0 +1,91 @@
+import logging
+import json
+import os
+import unittest
+from glob import glob
+from copy import copy
+from collections import namedtuple
+
+from kcloader.resource import ClientScopeResource, ClientScopeScopeMappingsRealmManager, \
+    ClientScopeProtocolMapperResource, ClientScopeProtocolMapperManager, \
+    ClientScopeScopeMappingsClientManager, ClientScopeScopeMappingsAllClientsManager, \
+    ClientScopeManager
+from kcloader.tools import read_from_json, find_in_list
+from ..helper import TestBed, remove_field_id, TestCaseBase
+from main import main
+
+logger = logging.getLogger(__name__)
+
+MainArgs = namedtuple("MainArgs", ["username", "password", "url", "datadir", "realm_name"])
+
+
+class TestCaseMain(TestCaseBase):
+    def setUp(self):
+        super().setUp()
+        self.main_args = MainArgs(
+            username=self.testbed.USER,
+            password=self.testbed.PASSWORD,
+            url=self.testbed.ENDPOINT,
+            datadir=self.testbed.DATADIR,
+            realm_name=self.testbed.REALM,
+        )
+
+
+class TestMain_remove_default_client_scope(TestCaseMain):
+    def setUp(self):
+        super().setUp()
+        testbed = self.testbed
+        self.client_scopes_api = testbed.kc.build("client-scopes", testbed.REALM)
+        self.default_default_client_scopes_api = testbed.kc.build("default-default-client-scopes", testbed.REALM)
+        self.default_optional_client_scopes_api = testbed.kc.build("default-optional-client-scopes", testbed.REALM)
+
+    def test_1(self):
+        """
+        Client scope is also (default or optional) default client scope.
+        main() needs to remove the client-scope.
+        But first client-scope needs to be removed from default client scopes.
+        """
+        def _check_state():
+            client_scopes_b = client_scopes_api.all()
+            default_default_client_scopes_b = default_default_client_scopes_api.all()
+            default_optional_client_scopes_b = default_optional_client_scopes_api.all()
+            self.assertEqual(client_scopes_a, client_scopes_b)
+            self.assertEqual(default_default_client_scopes_a, default_default_client_scopes_b)
+            self.assertEqual(default_optional_client_scopes_a, default_optional_client_scopes_b)
+
+        args = self.main_args
+        client_scopes_api = self.client_scopes_api
+        default_default_client_scopes_api = self.default_default_client_scopes_api
+        default_optional_client_scopes_api = self.default_optional_client_scopes_api
+
+        main(args)
+        client_scopes_a = client_scopes_api.all()
+        default_default_client_scopes_a = default_default_client_scopes_api.all()
+        default_optional_client_scopes_a = default_optional_client_scopes_api.all()
+        _check_state()
+
+        # create extra client scopes, and make them default
+        extra_def_client_scope_name = "ci0-client-scope-EXTRA-def"
+        extra_opt_client_scope_name = "ci0-client-scope-EXTRA-opt"
+        for extra_cs_name, extra_cs_api in zip(
+                [extra_def_client_scope_name, extra_opt_client_scope_name],
+                [default_default_client_scopes_api, default_optional_client_scopes_api]
+            ):
+            self.client_scopes_api.create(dict(
+                name=extra_cs_name,
+                description=extra_cs_name + "---CI-INJECTED",
+                protocol="openid-connect",
+            )).isOk()
+            extra_cs = self.client_scopes_api.findFirstByKV("name", extra_cs_name)
+            extra_cs_api.update(
+                extra_cs["id"],
+                dict(
+                    realm=self.testbed.REALM,
+                    clientScopeId=extra_cs["id"],
+                ),
+            )
+        # extra_def_client_scope = self.client_scopes_api.findFirstByKV("name", extra_def_client_scope_name)
+        # extra_opt_client_scope = self.client_scopes_api.findFirstByKV("name", extra_def_client_scope_name)
+
+        main(args)
+        _check_state()

--- a/test/kcloader/resource/test_default_client_scope_manager.py
+++ b/test/kcloader/resource/test_default_client_scope_manager.py
@@ -5,7 +5,7 @@ import unittest
 from glob import glob
 from copy import copy
 
-from kcloader.resource import DefaultDefaultClientScopeManager
+from kcloader.resource import DefaultDefaultClientScopeManager, DefaultOptionalClientScopeManager
 from kcloader.tools import read_from_json, find_in_list
 from ...helper import TestBed, remove_field_id, TestCaseBase
 
@@ -43,7 +43,10 @@ class TestDefaultDefaultClientScopeManager(TestCaseBase):
             self.assertEqual(default_default_client_scopes_a, default_default_client_scopes_b)
 
         default_default_client_scopes_api = self.default_default_client_scopes_api
-        default_default_client_scopes_filepath = os.path.join(self.testbed.DATADIR, f"ci0-realm/client-scopes/default/default-default-client-scopes.json")
+        default_default_client_scopes_filepath = os.path.join(
+            self.testbed.DATADIR,
+            f"ci0-realm/client-scopes/default/default-default-client-scopes.json",
+        )
         with open(default_default_client_scopes_filepath) as ff:
             expected_default_default_client_scopes_names = json.load(ff)
         ddcs_manager = DefaultDefaultClientScopeManager(
@@ -94,5 +97,93 @@ class TestDefaultDefaultClientScopeManager(TestCaseBase):
         self.assertTrue(creation_state)
         _check_state()
         creation_state = ddcs_manager.publish()
+        self.assertFalse(creation_state)
+        _check_state()
+
+
+class TestDefaultOptionalClientScopeManager(TestCaseBase):
+    def setUp(self):
+        super().setUp()
+        testbed = self.testbed
+
+        self.client0_clientId = "ci0-client-0"
+        self.client_scopes_api = testbed.kc.build("client-scopes", testbed.REALM)
+        self.default_optional_client_scopes_api = testbed.kc.build("default-optional-client-scopes", testbed.REALM)
+
+        # create required client-scope
+        self.client_scopes_api.create(dict(
+            name="ci0-client-scope-1-saml",
+            description="ci0-client-scope-1-saml---CI-INJECTED",
+            protocol="saml",
+        )).isOk()
+        extra_client_scope_name = "ci0-client-scope-EXTRA"
+        self.client_scopes_api.create(dict(
+            name=extra_client_scope_name,
+            description=extra_client_scope_name + "---CI-INJECTED",
+            protocol="openid-connect",
+        )).isOk()
+        self.extra_client_scope = self.client_scopes_api.findFirstByKV("name", extra_client_scope_name)
+
+    def test_publish(self):
+        def _check_state():
+            default_optional_client_scopes_b = default_optional_client_scopes_api.all()
+
+            self.assertEqual(default_optional_client_scopes_a[0]["id"], default_optional_client_scopes_b[0]["id"])
+            self.assertEqual(default_optional_client_scopes_a, default_optional_client_scopes_b)
+
+        default_optional_client_scopes_api = self.default_optional_client_scopes_api
+        default_optional_client_scopes_filepath = os.path.join(
+            self.testbed.DATADIR,
+            f"ci0-realm/client-scopes/default/default-optional-client-scopes.json",
+        )
+        with open(default_optional_client_scopes_filepath) as ff:
+            expected_default_optional_client_scopes_names = json.load(ff)
+        docs_manager = DefaultOptionalClientScopeManager(
+            self.testbed.kc,
+            self.testbed.REALM,
+            self.testbed.DATADIR,
+        )
+        # what is present in newly created realm
+        _default_optional_client_scopes_names___new_realm = sorted([
+            "address",
+            "microprofile-jwt",
+            "offline_access",
+            "phone",
+        ])
+
+        # check initial state
+        default_optional_client_scopes_a = default_optional_client_scopes_api.all()
+        default_optional_client_scopes_names = sorted([cs["name"] for cs in default_optional_client_scopes_a])
+        self.assertEqual(
+            _default_optional_client_scopes_names___new_realm,
+            default_optional_client_scopes_names,
+        )
+
+        # publish data - 1st time
+        creation_state = docs_manager.publish()
+        self.assertTrue(creation_state)
+        default_optional_client_scopes_a = default_optional_client_scopes_api.all()
+        _check_state()
+        # publish data - 2nd time, idempotence
+        creation_state = docs_manager.publish()
+        self.assertFalse(creation_state)
+        _check_state()
+
+        # modify something - add one extra client-scope
+        self.assertEqual(4 + 1, len(default_optional_client_scopes_api.all()))
+        default_optional_client_scopes_api.update(
+            self.extra_client_scope["id"],
+            dict(
+                realm=self.testbed.REALM,
+                clientScopeId=self.extra_client_scope["id"],
+            ),
+        )
+        self.assertEqual(4 + 2, len(default_optional_client_scopes_api.all()))
+        #
+        # .publish must revert change
+        creation_state = docs_manager.publish()
+        self.assertTrue(creation_state)
+        _check_state()
+        creation_state = docs_manager.publish()
         self.assertFalse(creation_state)
         _check_state()

--- a/test/kcloader/resource/test_default_client_scope_manager.py
+++ b/test/kcloader/resource/test_default_client_scope_manager.py
@@ -1,0 +1,98 @@
+import logging
+import json
+import os
+import unittest
+from glob import glob
+from copy import copy
+
+from kcloader.resource import DefaultDefaultClientScopeManager
+from kcloader.tools import read_from_json, find_in_list
+from ...helper import TestBed, remove_field_id, TestCaseBase
+
+logger = logging.getLogger(__name__)
+
+
+class TestDefaultDefaultClientScopeManager(TestCaseBase):
+    def setUp(self):
+        super().setUp()
+        testbed = self.testbed
+
+        self.client0_clientId = "ci0-client-0"
+        self.client_scopes_api = testbed.kc.build("client-scopes", testbed.REALM)
+        self.default_default_client_scopes_api = testbed.kc.build("default-default-client-scopes", testbed.REALM)
+
+        # create required client-scope
+        self.client_scopes_api.create(dict(
+            name="ci0-client-scope",
+            description="ci0-client-scope---CI-INJECTED",
+            protocol="openid-connect",
+        )).isOk()
+        extra_client_scope_name = "ci0-client-scope-EXTRA"
+        self.client_scopes_api.create(dict(
+            name=extra_client_scope_name,
+            description=extra_client_scope_name + "---CI-INJECTED",
+            protocol="openid-connect",
+        )).isOk()
+        self.extra_client_scope = self.client_scopes_api.findFirstByKV("name", extra_client_scope_name)
+
+    def test_publish(self):
+        def _check_state():
+            default_default_client_scopes_b = default_default_client_scopes_api.all()
+
+            self.assertEqual(default_default_client_scopes_a[0]["id"], default_default_client_scopes_b[0]["id"])
+            self.assertEqual(default_default_client_scopes_a, default_default_client_scopes_b)
+
+        default_default_client_scopes_api = self.default_default_client_scopes_api
+        default_default_client_scopes_filepath = os.path.join(self.testbed.DATADIR, f"ci0-realm/client-scopes/default/default-default-client-scopes.json")
+        with open(default_default_client_scopes_filepath) as ff:
+            expected_default_default_client_scopes_names = json.load(ff)
+        ddcs_manager = DefaultDefaultClientScopeManager(
+            self.testbed.kc,
+            self.testbed.REALM,
+            self.testbed.DATADIR,
+        )
+        # what is present in newly created realm
+        _default_default_client_scopes_names___new_realm = sorted([
+            "email",
+            "profile",
+            "role_list",
+            "roles",
+            "web-origins",
+        ])
+
+        # check initial state
+        default_default_client_scopes_a = default_default_client_scopes_api.all()
+        default_default_client_scopes_names = sorted([cs["name"] for cs in default_default_client_scopes_a])
+        self.assertEqual(
+            _default_default_client_scopes_names___new_realm,
+            default_default_client_scopes_names,
+        )
+
+        # publish data - 1st time
+        creation_state = ddcs_manager.publish()
+        self.assertTrue(creation_state)
+        default_default_client_scopes_a = default_default_client_scopes_api.all()
+        _check_state()
+        # publish data - 2nd time, idempotence
+        creation_state = ddcs_manager.publish()
+        self.assertFalse(creation_state)
+        _check_state()
+
+        # modify something - add one client-scope
+        self.assertEqual(5 + 1, len(default_default_client_scopes_api.all()))
+        default_default_client_scopes_api.update(
+            self.extra_client_scope["id"],
+            dict(
+                realm=self.testbed.REALM,
+                clientScopeId=self.extra_client_scope["id"],
+            ),
+        )
+        self.assertEqual(5 + 2, len(default_default_client_scopes_api.all()))
+        #
+        # .publish must revert change
+        creation_state = ddcs_manager.publish()
+        self.assertTrue(creation_state)
+        _check_state()
+        creation_state = ddcs_manager.publish()
+        self.assertFalse(creation_state)
+        _check_state()

--- a/test/kcloader/resource/test_default_client_scope_manager.py
+++ b/test/kcloader/resource/test_default_client_scope_manager.py
@@ -72,12 +72,12 @@ class TestDefaultDefaultClientScopeManager(TestCaseBase):
         )
 
         # publish data - 1st time
-        creation_state = ddcs_manager.publish()
+        creation_state = ddcs_manager.publish(setup_new_links=True)
         self.assertTrue(creation_state)
         default_default_client_scopes_a = default_default_client_scopes_api.all()
         _check_state()
         # publish data - 2nd time, idempotence
-        creation_state = ddcs_manager.publish()
+        creation_state = ddcs_manager.publish(setup_new_links=True)
         self.assertFalse(creation_state)
         _check_state()
 
@@ -93,13 +93,78 @@ class TestDefaultDefaultClientScopeManager(TestCaseBase):
         self.assertEqual(5 + 2, len(default_default_client_scopes_api.all()))
         #
         # .publish must revert change
-        creation_state = ddcs_manager.publish()
+        creation_state = ddcs_manager.publish(setup_new_links=True)
         self.assertTrue(creation_state)
         _check_state()
-        creation_state = ddcs_manager.publish()
+        creation_state = ddcs_manager.publish(setup_new_links=True)
         self.assertFalse(creation_state)
         _check_state()
 
+
+    def test_publish__setup_new_links_false(self):
+        def _check_state():
+            default_default_client_scopes_b = default_default_client_scopes_api.all()
+
+            self.assertEqual(default_default_client_scopes_a[0]["id"], default_default_client_scopes_b[0]["id"])
+            self.assertEqual(default_default_client_scopes_a, default_default_client_scopes_b)
+
+        default_default_client_scopes_api = self.default_default_client_scopes_api
+        default_default_client_scopes_filepath = os.path.join(
+            self.testbed.DATADIR,
+            f"ci0-realm/client-scopes/default/default-default-client-scopes.json",
+        )
+        with open(default_default_client_scopes_filepath) as ff:
+            expected_default_default_client_scopes_names = json.load(ff)
+        ddcs_manager = DefaultDefaultClientScopeManager(
+            self.testbed.kc,
+            self.testbed.REALM,
+            self.testbed.DATADIR,
+        )
+        # what is present in newly created realm
+        _default_default_client_scopes_names___new_realm = sorted([
+            "email",
+            "profile",
+            "role_list",
+            "roles",
+            "web-origins",
+        ])
+
+        # check initial state
+        default_default_client_scopes_a = default_default_client_scopes_api.all()
+        default_default_client_scopes_names = sorted([cs["name"] for cs in default_default_client_scopes_a])
+        self.assertEqual(
+            _default_default_client_scopes_names___new_realm,
+            default_default_client_scopes_names,
+        )
+
+        # publish data - 1st time
+        creation_state = ddcs_manager.publish(setup_new_links=False)
+        self.assertFalse(creation_state)  # nothing was done, but change is needed
+        default_default_client_scopes_a = default_default_client_scopes_api.all()
+        _check_state()
+        # publish data - 2nd time, idempotence
+        creation_state = ddcs_manager.publish(setup_new_links=False)
+        self.assertFalse(creation_state)
+        _check_state()
+
+        # modify something - add one client-scope
+        self.assertEqual(5 + 0, len(default_default_client_scopes_api.all()))
+        default_default_client_scopes_api.update(
+            self.extra_client_scope["id"],
+            dict(
+                realm=self.testbed.REALM,
+                clientScopeId=self.extra_client_scope["id"],
+            ),
+        )
+        self.assertEqual(5 + 1, len(default_default_client_scopes_api.all()))
+        #
+        # .publish must revert change
+        creation_state = ddcs_manager.publish(setup_new_links=False)
+        self.assertTrue(creation_state)
+        _check_state()
+        creation_state = ddcs_manager.publish(setup_new_links=False)
+        self.assertFalse(creation_state)
+        _check_state()
 
 class TestDefaultOptionalClientScopeManager(TestCaseBase):
     def setUp(self):
@@ -160,12 +225,12 @@ class TestDefaultOptionalClientScopeManager(TestCaseBase):
         )
 
         # publish data - 1st time
-        creation_state = docs_manager.publish()
+        creation_state = docs_manager.publish(setup_new_links=True)
         self.assertTrue(creation_state)
         default_optional_client_scopes_a = default_optional_client_scopes_api.all()
         _check_state()
         # publish data - 2nd time, idempotence
-        creation_state = docs_manager.publish()
+        creation_state = docs_manager.publish(setup_new_links=True)
         self.assertFalse(creation_state)
         _check_state()
 
@@ -181,9 +246,9 @@ class TestDefaultOptionalClientScopeManager(TestCaseBase):
         self.assertEqual(4 + 2, len(default_optional_client_scopes_api.all()))
         #
         # .publish must revert change
-        creation_state = docs_manager.publish()
+        creation_state = docs_manager.publish(setup_new_links=True)
         self.assertTrue(creation_state)
         _check_state()
-        creation_state = docs_manager.publish()
+        creation_state = docs_manager.publish(setup_new_links=True)
         self.assertFalse(creation_state)
         _check_state()


### PR DESCRIPTION
default default client scopes and default optional client scopes are published.
If client scope needs to be removed, it is first unassigned from default client scopes.