### PR TITLE
Do not modify builtin flows at all

### DIFF
--- a/kcloader/resource/base_manager.py
+++ b/kcloader/resource/base_manager.py
@@ -48,12 +48,13 @@ class BaseManager(ABC):
     def publish(self, **publish_kwargs):
         create_ids, delete_objs = self._difference_ids()
         status_resources = [resource.publish(**publish_kwargs) for resource in self.resources]
-        status_deleted = False
-        for delete_obj in delete_objs:
-            delete_id = delete_obj[self._resource_delete_id]
-            self.resource_api.remove(delete_id).isOk()
-            status_deleted = True
-        return any(status_resources + [status_deleted])
+        status_deleted = [self.remove_server_object(delete_obj) for delete_obj in delete_objs]
+        return any(status_resources + status_deleted)
+
+    def remove_server_object(self, delete_obj: dict):
+        delete_id = delete_obj[self._resource_delete_id]
+        self.resource_api.remove(delete_id).isOk()
+        return True
 
     # def _object_filepaths(self):
     #     object_filepaths = glob(os.path.join(self.datadir, f"{self.realm}/clients/*/*.json"))

--- a/kcloader/resource/base_manager.py
+++ b/kcloader/resource/base_manager.py
@@ -93,6 +93,11 @@ class BaseManager(ABC):
 
         # auth execution manager - It can have nonunique displayName.
         # Try to be ignorant...
+        if len(server_ids) != len(set(server_ids)):
+            extra_msg = ""
+            if type(self).__name__ == "AuthenticationFlowExecutionsManager":
+                extra_msg = f"self.flow_alias={self.flow_alias}"
+            logger.exception(f"ID values should are not unique - {extra_msg} len(file_ids)={len(file_ids)}, len(set(server_ids))={len(set(server_ids))}, file_ids={file_ids}, server_ids={server_ids}, ")
         assert len(file_ids) == len(set(file_ids))
         assert len(server_ids) == len(set(server_ids))
         # TODO - combo displayName+alias should be used.

--- a/kcloader/resource/custom_authentication_resource.py
+++ b/kcloader/resource/custom_authentication_resource.py
@@ -224,6 +224,15 @@ class AuthenticationFlowExecutionsManager(BaseManager):
         }
         self.resources = flow_executors_factory.create_child_executors(resource)
 
+    def publish(self, **publish_kwargs):
+        if self._builtin_flow:
+            # TODO if _builtin_flow, then execution.requirement value can be changed,
+            # but new executions/subflows cannot be added/removed.
+            # Hack - just ignore executions if _builtin_flow.
+            logger.warning(f"realm={self.realm} flow_alias={self.flow_alias} is built-in, executions will not be updated.")
+            return False
+        return super().publish(**publish_kwargs)
+
     def _object_docs_ids(self):
         return [resource.body["displayName"] for resource in self.resources]
 


### PR DESCRIPTION
Problem: if some execution `requirement` value is changed, than this is not applied.
But this is not our usecase anyway, builtin flows are not modified at all.